### PR TITLE
load env in db config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-react": "^7.3.0",
     "expect": "^1.20.2",
     "favicons-webpack-plugin": "0.0.7",
+    "foreground-child": "^2.0.0",
     "html-webpack-plugin": "^2.29.0",
     "jest": "^21.2.1",
     "jest-localstorage-mock": "^2.1.0",

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 module.exports = {
   development: {
     username: process.env.DB_USER,


### PR DESCRIPTION
The DB config makes use of environment variables. When the application is setup for the first time on a local machine, environment variables are ignored while trying to set up the database. This PR ensures  environment variables are set before configuring the database.